### PR TITLE
DM-52110-hotfix: Use skipif instead of skipUnless

### DIFF
--- a/metadetect/lsst/tests/test_lsst_conventions.py
+++ b/metadetect/lsst/tests/test_lsst_conventions.py
@@ -18,9 +18,9 @@ logging.basicConfig(
 try:
     getPackageDir('descwl_shear_sims')
     getPackageDir('descwl_coadd')
-    run_tests_on_simulations = True
+    skip_tests_on_simulations = False
 except LookupError:
-    run_tests_on_simulations = False
+    skip_tests_on_simulations = True
 
 
 def make_lsst_sim(rng, g1, g2, mag=20, hlr=1.0):
@@ -85,8 +85,8 @@ def do_coadding(rng, sim_data, nowarp):
     return util.extract_multiband_coadd_data(coadd_data_list)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 @pytest.mark.parametrize('ginput', [

--- a/metadetect/lsst/tests/test_lsst_exp2obs.py
+++ b/metadetect/lsst/tests/test_lsst_exp2obs.py
@@ -7,9 +7,9 @@ from lsst.utils import getPackageDir
 
 try:
     getPackageDir('descwl_shear_sims')
-    run_tests_on_simulations = True
+    skip_tests_on_simulations = False
 except LookupError:
-    run_tests_on_simulations = False
+    skip_tests_on_simulations = True
 
 
 def make_lsst_sim(rng, dim, mag=22, hlr=0.5, bands=['i']):
@@ -42,8 +42,8 @@ def make_lsst_sim(rng, dim, mag=22, hlr=0.5, bands=['i']):
     return sim_data
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims not available'
 )
 @pytest.mark.parametrize('copy_mask_to', ['ormask', 'bmask'])

--- a/metadetect/lsst/tests/test_lsst_masking.py
+++ b/metadetect/lsst/tests/test_lsst_masking.py
@@ -11,9 +11,9 @@ from lsst.utils import getPackageDir
 try:
     getPackageDir('descwl_shear_sims')
     getPackageDir('descwl_coadd')
-    run_tests_on_simulations = True
+    skip_tests_on_simulations = False
 except LookupError:
-    run_tests_on_simulations = False
+    skip_tests_on_simulations = True
 
 
 def make_lsst_sim(
@@ -80,8 +80,8 @@ def do_coadding(rng, sim_data, nowarp):
     return util.extract_multiband_coadd_data(coadd_data_list)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_apply_apodized_bright_masks(show=False):
@@ -225,8 +225,8 @@ def extract_cell_mbexp(mbexp, cell_size, start_x, start_y):
     return copy_mbexp(get_mbexp(subexps))
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_apply_apodized_bright_masks_subexp(show=False):
@@ -356,8 +356,8 @@ def test_apply_apodized_bright_masks_subexp(show=False):
         assert np.all(nexp.variance.array[w] != np.inf)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_apply_apodized_edge_masks(show=False):
@@ -417,8 +417,8 @@ def test_apply_apodized_edge_masks(show=False):
         assert np.all(nexp.image.array[w] != noise_image[w])
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_apply_apodized_bright_masks_metadetect(show=False):

--- a/metadetect/lsst/tests/test_lsst_metacal_exposures.py
+++ b/metadetect/lsst/tests/test_lsst_metacal_exposures.py
@@ -12,13 +12,13 @@ from lsst.utils import getPackageDir
 
 try:
     getPackageDir('descwl_shear_sims')
-    run_tests_on_simulations = True
+    skip_tests_on_simulations = False
 except LookupError:
-    run_tests_on_simulations = False
+    skip_tests_on_simulations = True
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims not available'
 )
 def test_metacal_exps(ntrial=10, show=False):
@@ -113,8 +113,8 @@ def test_metacal_exps(ntrial=10, show=False):
             assert np.all(tweight == eweight)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims not available'
 )
 def test_metacal_mbexp(ntrial=10, show=False):

--- a/metadetect/lsst/tests/test_lsst_metadetect.py
+++ b/metadetect/lsst/tests/test_lsst_metadetect.py
@@ -18,9 +18,9 @@ from lsst.utils import getPackageDir
 try:
     getPackageDir('descwl_shear_sims')
     getPackageDir('descwl_coadd')
-    run_tests_on_simulations = True
+    skip_tests_on_simulations = False
 except LookupError:
-    run_tests_on_simulations = False
+    skip_tests_on_simulations = True
 
 
 ngmix_v = float(ngmix.__version__[:3])
@@ -95,8 +95,8 @@ def do_coadding(rng, sim_data, nowarp):
     return util.extract_multiband_coadd_data(coadd_data_list)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 @pytest.mark.parametrize('meas_type', [None, 'wmom', 'ksigma', 'pgauss'])
@@ -159,8 +159,8 @@ def test_lsst_metadetect_smoke(meas_type, subtract_sky, metacal_types_option):
         assert len(res[shear][flux_name][0]) == len(bands)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 @pytest.mark.skipif(ngmix_v < 2.1, reason="requires ngmix 2.1 or higher")
@@ -205,8 +205,8 @@ def test_lsst_metadetect_weight(meas_type, fwhm_smooth):
         assert len(res[shear][flux_name][0]) == len(bands)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 @pytest.mark.parametrize('fwhm_reg', [0, 0.8])
@@ -247,8 +247,8 @@ def test_lsst_metadetect_fwhm_reg(fwhm_reg):
         assert len(res[shear][flux_name][0]) == len(bands)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_lsst_metadetect_fwhm_reg_shapenoise():
@@ -282,8 +282,8 @@ def test_lsst_metadetect_fwhm_reg_shapenoise():
     assert sdevs[0.8] < 0.6 * sdevs[0]
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_lsst_metadetect_am():
@@ -315,8 +315,8 @@ def test_lsst_metadetect_am():
             len(res[shear][flux_name][0])
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_lsst_metadetect_gauss():
@@ -346,8 +346,8 @@ def test_lsst_metadetect_gauss():
         assert np.all(np.isfinite(res[shear][flux_name]))
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_lsst_metadetect_fullcoadd_smoke():
@@ -376,8 +376,8 @@ def test_lsst_metadetect_fullcoadd_smoke():
         assert len(res[shear][flux_name][0]) == len(bands)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_lsst_zero_weights(show=False):
@@ -422,8 +422,8 @@ def test_lsst_zero_weights(show=False):
     assert nobj[0] == nobj[1]
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_lsst_masked_as_bright(show=False):
@@ -469,8 +469,8 @@ def test_lsst_masked_as_bright(show=False):
                 assert tres.size == 25
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 @pytest.mark.parametrize('meas_type', ['ksigma', 'pgauss'])
@@ -503,8 +503,8 @@ def test_lsst_metadetect_prepsf_stars(meas_type):
             assert np.all(np.isfinite(data[field][wgood])), field
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 def test_lsst_metadetect_mfrac_ormask(show=False):

--- a/metadetect/lsst/tests/test_lsst_noise_replacers.py
+++ b/metadetect/lsst/tests/test_lsst_noise_replacers.py
@@ -8,9 +8,9 @@ from lsst.utils import getPackageDir
 
 try:
     getPackageDir('descwl_shear_sims')
-    run_tests_on_simulations = True
+    skip_tests_on_simulations = False
 except LookupError:
-    run_tests_on_simulations = False
+    skip_tests_on_simulations = True
 
 logging.basicConfig(stream=sys.stdout, level=logging.WARN)
 
@@ -114,8 +114,8 @@ def detect_and_deblend(mbexp):
     return sources
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims not available'
 )
 def test_noise_replacer():
@@ -145,8 +145,8 @@ def test_noise_replacer():
     assert np.all(exp_copy.image.array == exposure.image.array)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims not available'
 )
 def test_multiband_noise_replacer(show=False):

--- a/metadetect/lsst/tests/test_lsst_photometry.py
+++ b/metadetect/lsst/tests/test_lsst_photometry.py
@@ -13,9 +13,9 @@ from lsst.utils import getPackageDir
 try:
     getPackageDir('descwl_shear_sims')
     getPackageDir('descwl_coadd')
-    run_tests_on_simulations = True
+    skip_tests_on_simulations = False
 except LookupError:
-    run_tests_on_simulations = False
+    skip_tests_on_simulations = True
 
 logging.basicConfig(
     stream=sys.stdout,
@@ -87,8 +87,8 @@ def do_coadding(rng, sim_data, nowarp):
     return util.extract_multiband_coadd_data(coadd_data_list)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims and/or descwl_coadd not available'
 )
 @pytest.mark.parametrize('meas_type', [None, 'wmom', 'ksigma', 'pgauss'])

--- a/metadetect/lsst/tests/test_lsst_skysub.py
+++ b/metadetect/lsst/tests/test_lsst_skysub.py
@@ -10,9 +10,9 @@ from lsst.utils import getPackageDir
 
 try:
     getPackageDir('descwl_shear_sims')
-    run_tests_on_simulations = True
+    skip_tests_on_simulations = False
 except LookupError:
-    run_tests_on_simulations = False
+    skip_tests_on_simulations = True
 
 logging.basicConfig(
     stream=sys.stdout,
@@ -170,8 +170,8 @@ def test_skysub_pure_noise():
     check_skysub(meanvals, errvals, noise, true_sky=0)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims not available'
 )
 def test_skysub_sim_smoke():
@@ -187,8 +187,8 @@ def test_skysub_sim_smoke():
     assert 'BGVAR' in meta
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims not available'
 )
 @pytest.mark.parametrize('sky_n_sigma', [-0.5, -2.0, -100.0])
@@ -231,8 +231,8 @@ def test_skysub_sim_fixed_gal(sky_n_sigma):
     check_skysub(meanvals, errvals, image_noise, true_sky=true_sky)
 
 
-@pytest.mark.skipUnless(
-    run_tests_on_simulations,
+@pytest.mark.skipif(
+    skip_tests_on_simulations,
     reason='descwl_shear_sims not available'
 )
 @pytest.mark.skipif(


### PR DESCRIPTION
`pytest` doesn't have a `skipUnless` like `unittest`, and using non-existent marks emit warnings instead of errors. This means that these tests weren't made optional correctly. I'm glad I caught it before the weekly tag.